### PR TITLE
new name sporing, still support umami

### DIFF
--- a/src/tracker/sporing-dev.js
+++ b/src/tracker/sporing-dev.js
@@ -40,8 +40,9 @@
     hostUrl || "" || currentScript.src.split("/").slice(0, -1).join("/");
   const endpoint = `${host.replace(/\/$/, "")}/api/send`;
   const screen = `${width}x${height}`;
-  const eventRegex = /data-umami-event-([\w-_]+)/;
-  const eventNameAttribute = `${_data}umami-event`;
+  const eventRegex = /data-(?:sporing|umami)-event-([\w-_]+)/;
+  const eventNameAttribute = `${_data}sporing-event`;
+  const eventNameAttributeLegacy = `${_data}umami-event`;
   const delayDuration = 300;
 
   /* Helper functions */
@@ -102,7 +103,7 @@
 
   const handleClicks = () => {
     const trackElement = async (el) => {
-      const eventName = el.getAttribute(eventNameAttribute);
+      const eventName = el.getAttribute(eventNameAttribute) || el.getAttribute(eventNameAttributeLegacy);
       if (eventName) {
         const eventData = {};
 
@@ -120,7 +121,7 @@
       if (!parentElement) return trackElement(el);
 
       const { href, target } = parentElement;
-      if (!parentElement.getAttribute(eventNameAttribute)) return;
+      if (!parentElement.getAttribute(eventNameAttribute) && !parentElement.getAttribute(eventNameAttributeLegacy)) return;
 
       if (parentElement.tagName === "BUTTON") {
         return trackElement(parentElement);
@@ -148,6 +149,7 @@
   const trackingDisabled = () =>
     disabled ||
     !website ||
+    localStorage?.getItem("sporing.disabled") ||
     localStorage?.getItem("umami.disabled") ||
     (domain && !domains.includes(hostname)) ||
     (dnt && hasDoNotTrack());
@@ -221,11 +223,16 @@
 
   /* Start */
 
-  if (!window.umami) {
-    window.umami = {
+  if (!window.sporing) {
+    window.sporing = {
       track,
       identify,
     };
+  }
+
+  // Backwards compatibility
+  if (!window.umami) {
+    window.umami = window.sporing;
   }
 
   let currentUrl = normalize(href);

--- a/src/tracker/sporing.js
+++ b/src/tracker/sporing.js
@@ -43,8 +43,9 @@
     hostUrl || "" || currentScript.src.split("/").slice(0, -1).join("/");
   const endpoint = `${host.replace(/\/$/, "")}/api/send`;
   const screen = `${width}x${height}`;
-  const eventRegex = /data-umami-event-([\w-_]+)/;
-  const eventNameAttribute = `${_data}umami-event`;
+  const eventRegex = /data-(?:sporing|umami)-event-([\w-_]+)/;
+  const eventNameAttribute = `${_data}sporing-event`;
+  const eventNameAttributeLegacy = `${_data}umami-event`;
   const delayDuration = 300;
 
   /* Helper functions */
@@ -105,7 +106,7 @@
 
   const handleClicks = () => {
     const trackElement = async (el) => {
-      const eventName = el.getAttribute(eventNameAttribute);
+      const eventName = el.getAttribute(eventNameAttribute) || el.getAttribute(eventNameAttributeLegacy);
       if (eventName) {
         const eventData = {};
 
@@ -123,7 +124,7 @@
       if (!parentElement) return trackElement(el);
 
       const { href, target } = parentElement;
-      if (!parentElement.getAttribute(eventNameAttribute)) return;
+      if (!parentElement.getAttribute(eventNameAttribute) && !parentElement.getAttribute(eventNameAttributeLegacy)) return;
 
       if (parentElement.tagName === "BUTTON") {
         return trackElement(parentElement);
@@ -151,6 +152,7 @@
   const trackingDisabled = () =>
     disabled ||
     !website ||
+    localStorage?.getItem("sporing.disabled") ||
     localStorage?.getItem("umami.disabled") ||
     (domain && !domains.includes(hostname)) ||
     (dnt && hasDoNotTrack());
@@ -224,11 +226,16 @@
 
   /* Start */
 
-  if (!window.umami) {
-    window.umami = {
+  if (!window.sporing) {
+    window.sporing = {
       track,
       identify,
     };
+  }
+
+  // Backwards compatibility
+  if (!window.umami) {
+    window.umami = window.sporing;
   }
 
   let currentUrl = normalize(href);


### PR DESCRIPTION
<!-- pr-banner -->
## ✨ new name sporing, still support umami

![PR Banner](https://raw.githubusercontent.com/JulianNymark/pr-banner-images/main/rename-to-sporing-backwards-compat-umami-pr22.jpg)

<sub>🎨 Generated by [pr-banner](https://chakra.fly.dev/j/scripts/src/branch/main/deno/pr_banner.ts)</sub>

<!-- /pr-banner -->

---

should do the same as the previous commit did to `sporing-reops.js`, check that it's nothing new, the sporing-reops script can be tested live and working here: https://sporingsskript-test.ansatt.dev.nav.no/sporing/identify/simple